### PR TITLE
fix: fix the usage of object probability

### DIFF
--- a/src/tensorrt_yolox_node.cpp
+++ b/src/tensorrt_yolox_node.cpp
@@ -92,10 +92,11 @@ void TrtYoloXNode::onImage(const sensor_msgs::msg::Image::ConstSharedPtr msg)
     object.feature.roi.y_offset = yolox_object.y_offset;
     object.feature.roi.width = yolox_object.width;
     object.feature.roi.height = yolox_object.height;
+    object.object.existence_probability = yolox_object.score;
     object.object.classification.emplace_back(
       autoware_auto_perception_msgs::build<Label>()
       .label(Label::UNKNOWN)
-      .probability(yolox_object.score));
+      .probability(1.0));
     if (label_map_[yolox_object.type] == "CAR") {
       object.object.classification.front().label = Label::CAR;
     } else if (label_map_[yolox_object.type] == "PEDESTRIAN") {


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## Description

The usage probability is incorrect and it affects to the camera-lidar-fusion program.

In autoware, `existence_probability` is the probability of the objectness and `probability` is the classification probability of the multi-labels